### PR TITLE
Add ability to console.dir highlighted variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # - name: Run tests
-      #   env:
-      #     DISPLAY: ':99.0'
-      #   run: npm test
+      - name: Run tests
+        env:
+          DISPLAY: ':99.0'
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        env:
-          DISPLAY: ':99.0'
-        run: npm test
+      # - name: Run tests
+      #   env:
+      #     DISPLAY: ':99.0'
+      #   run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,6 @@ jobs:
       - name: Run tests
         env:
           DISPLAY: ':99.0'
-        run: npm test
+        run: |
+          mkdir -p test-results
+          npm test -- --reporter spec --reporter-options mochaFile=test-results/test-results.xml | tee test-results/test-output.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,12 +6,10 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			]
-		}
+      "name": "Run Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}", "${workspaceFolder}/tempWorkspace"]
+    }
 	]
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,18 @@
     "Other"
   ],
   "activationEvents": [],
-  "main": "./extension.js",
+  "main": "./src/extension.js",
   "contributes": {
-    "commands": [{
-      "command": "logify.helloWorld",
-      "title": "Hello World"
-    }]
+    "commands": [
+      {
+        "command": "logify.helloWorld",
+        "title": "Hello World"
+      },
+      {
+        "command": "logify.addConsole",
+        "title": "Add console.dir()"
+      }
+    ]
   },
   "scripts": {
     "lint": "eslint .",

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,15 +2,47 @@
 
 const vscode = require('vscode')
 
+function addConsole() {
+	const editor = vscode.window.activeTextEditor
+	const document = editor.document
+	const highlightedVariable = getHighlightedVariable()
+
+	if (highlightedVariable) {
+		const { linePosition, highlightedText } = highlightedVariable
+
+		if (linePosition >= 0 && linePosition <= document.lineCount) {
+			editor.edit((editBuilder) => {
+					if (linePosition + 1 === document.lineCount) {
+							const position = new vscode.Position(linePosition + 1, 0)
+							editBuilder.insert(position, '\n' + `console.dir(${highlightedText}, { depth: null, color: true })`)
+					} else {
+							const position = new vscode.Position(linePosition + 1, 0)
+							editBuilder.insert(position, `console.dir(${highlightedText}, { depth: null, color: true })` + '\n')
+					}
+			}).then(success => {
+					if (success) {
+							console.log('Console statement added successfully.')
+					} else {
+							console.error('Failed to add console statement.')
+					}
+			})
+		}
+	}
+}
 function getHighlightedVariable() {
 	const editor = vscode.window.activeTextEditor
 	const selection = editor.selection
 
 	if (selection && !selection.isEmpty) {
     const selectionRange = new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character)
-    const highlighted = editor.document.getText(selectionRange)
 
-		return highlighted
+    const highlightedText = editor.document.getText(selectionRange)
+		const linePosition = selection.end.line
+
+		return {
+			highlightedText,
+			linePosition
+		}
 	}
 
 	return null

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const vscode = require('vscode')
+
+function getHighlightedVariable() {
+	const editor = vscode.window.activeTextEditor
+	const selection = editor.selection
+
+	if (selection && !selection.isEmpty) {
+    const selectionRange = new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character)
+    const highlighted = editor.document.getText(selectionRange)
+
+		return highlighted
+	}
+
+	return null
+}
+
+function addConsole() {
+	const selection = getHighlightedVariable()
+	console.log(selection)
+}
+
+module.exports = {
+  addConsole
+}

--- a/src/commands.js
+++ b/src/commands.js
@@ -16,19 +16,19 @@ function addConsole() {
 
 		if (linePosition >= 0 && linePosition <= document.lineCount) {
 			editor.edit((editBuilder) => {
-					if (linePosition + 1 === document.lineCount) {
-							const position = new vscode.Position(linePosition + 1, 0)
-							editBuilder.insert(position, '\n' + `console.dir(${highlightedText}, { depth: null, color: true })`)
-					} else {
-							const position = new vscode.Position(linePosition + 1, 0)
-							editBuilder.insert(position, `console.dir(${highlightedText}, { depth: null, color: true })` + '\n')
-					}
+				if (linePosition + 1 === document.lineCount) {
+					const position = new vscode.Position(linePosition + 1, 0)
+					editBuilder.insert(position, '\n' + `console.dir(${highlightedText}, { depth: null, color: true })`)
+				} else {
+					const position = new vscode.Position(linePosition + 1, 0)
+					editBuilder.insert(position, `console.dir(${highlightedText}, { depth: null, color: true })` + '\n')
+				}
 			}).then(success => {
-					if (success) {
-							console.log('Console statement added successfully.')
-					} else {
-							console.error('Failed to add console statement.')
-					}
+				if (success) {
+					console.log('Console statement added successfully.')
+				} else {
+					console.error('Failed to add console statement.')
+				}
 			})
 		}
 	}

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,6 +2,10 @@
 
 const vscode = require('vscode')
 
+/**
+ * Inserts a print statement underneath the highlighted variable. Determines if the highlighted variable is on the last
+ * line in the document and works accordingly to add a new line to populate with a print statement.
+ */
 function addConsole() {
 	const editor = vscode.window.activeTextEditor
 	const document = editor.document
@@ -29,6 +33,13 @@ function addConsole() {
 		}
 	}
 }
+
+/**
+ * Retrieves the currently highlighted text from the document and returns the highlighted variable and its
+ * line position.
+ *
+ * @returns {object} Returns the highlighted text and the line it is located at on the document.
+ */
 function getHighlightedVariable() {
 	const editor = vscode.window.activeTextEditor
 	const selection = editor.selection
@@ -46,11 +57,6 @@ function getHighlightedVariable() {
 	}
 
 	return null
-}
-
-function addConsole() {
-	const selection = getHighlightedVariable()
-	console.log(selection)
 }
 
 module.exports = {

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,9 @@
+'use strict'
+
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
+const { addConsole } = require('./commands')
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -24,7 +27,13 @@ function activate(context) {
 		vscode.window.showInformationMessage('Hello World from logify!');
 	});
 
-	context.subscriptions.push(disposable);
+	const addConsoleCommand = vscode.commands.registerCommand('logify.addConsole', function () {
+		addConsole()
+		vscode.window.showInformationMessage('Activate console command');
+	});
+
+	context.subscriptions.push(disposable)
+	context.subscriptions.push(addConsoleCommand)
 }
 
 // This method is called when your extension is deactivated

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -66,8 +66,9 @@ describe('Commands', function () {
         const editor = vscode.window.activeTextEditor
         editor.selection = new vscode.Selection(3, 6, 3, 17)
 
-        assert.strictEqual(result, 'const myVariable = 42\nconsole.dir(myVariable, { depth: null, color: true })')
+        // Execute the command and wait 0.2 seconds as the tests are running too fast
         await vscode.commands.executeCommand('logify.addConsole')
+        await new Promise(resolve => setTimeout(resolve, 200))
 
         const result = await editor.document.getText()
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const { it, describe, before, beforeEach, afterEach } = require('mocha')
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const vscode = require('vscode')
+
+describe('Commands', function () {
+  let tempWorkspacePath
+
+  beforeEach(async function () {
+    // Create the temporary workspace folder
+    tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
+
+    if (!fs.existsSync(tempWorkspacePath)) {
+      fs.mkdirSync(tempWorkspacePath)
+    }
+
+    // Constructs a new file path for a file
+    const workspaceFolder = vscode.Uri.file(tempWorkspacePath)
+    await vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
+  })
+
+  afterEach(function () {
+    if (!fs.existsSync(tempWorkspacePath)) {
+      fs.rmdir(tempWorkspacePath)
+    }
+
+
+  })
+
+  describe('addConsole() command', function () {
+    describe('when a file has only the variable', function () {
+      before(async function () {
+        // Create a new .js file and add content
+        const document = await vscode.workspace.openTextDocument({
+          content: 'const myVariable = 42',
+          language: 'javascript'
+        })
+
+        await vscode.window.showTextDocument(document)
+      })
+
+      it('Adds a console underneath the highlighted variable', async function () {
+        // Select the highlighted variable
+        const editor = vscode.window.activeTextEditor
+        editor.selection = new vscode.Selection(0, 6, 0, 16)
+
+        await vscode.commands.executeCommand('logify.addConsole')
+
+        const result = editor.document.getText()
+
+        assert.strictEqual(result, 'const myVariable = 42\nconsole.dir(myVariable, { depth: null, color: true })')
+      })
+    })
+  })
+})

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -10,7 +10,7 @@ const vscode = require('vscode')
 describe('Commands', function () {
   let tempWorkspacePath
 
-  beforeEach(function () {
+  before(async function () {
     // Set up a clean workspace before each test
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
 
@@ -20,7 +20,15 @@ describe('Commands', function () {
 
     // Constructs a new file path for a file
     const workspaceFolder = vscode.Uri.file(tempWorkspacePath)
-    return vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
+    vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
+
+    // Create a new .js file and add content
+    const document = await vscode.workspace.openTextDocument({
+      content: 'const variableOne = 42\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment',
+      language: 'javascript'
+    })
+
+    await vscode.window.showTextDocument(document)
   })
 
   afterEach(function () {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -11,17 +11,11 @@ describe('Commands', function () {
   let tempWorkspacePath
 
   before(async function () {
-    console.log("log 1: Before commands.js test execution is running")
-
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
-
-    console.log("log 2: After tempWorkspacePath")
 
     if (!fs.existsSync(tempWorkspacePath)) {
       fs.mkdirSync(tempWorkspacePath)
     }
-
-    console.log("log 3: After creating directory")
 
     try {
       // Wait for the workspace to be ready
@@ -33,11 +27,7 @@ describe('Commands', function () {
         language: 'javascript'
       })
 
-      console.log("log 5: After creating the .js file")
-
       const editor = await vscode.window.showTextDocument(document, { preview: false, preserveFocus: false })
-
-      console.log("log 6: After opening the text document")
 
       // Ensure the editor is ready before moving on
       await new Promise(resolve => setTimeout(resolve, 500))
@@ -45,10 +35,7 @@ describe('Commands', function () {
       if (!editor) {
         throw new Error("Failed to open text document in the editor")
       }
-
-      console.log("log 7: Before commands.js test execution finished running")
     } catch (error) {
-      console.error("Error in before hook:", error)
       throw error
     }
   })
@@ -70,7 +57,6 @@ describe('Commands', function () {
   describe('addConsole() command', function () {
     describe('when there is no content surrounding the variable', function () {
       it('adds a console underneath the highlighted variable', async function () {
-        console.log("Before commands.js test execution is running")
         // Select the highlighted variable
         const editor = vscode.window.activeTextEditor
         editor.selection = new vscode.Selection(0, 6, 0, 17)

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -11,7 +11,6 @@ describe('Commands', function () {
   let tempWorkspacePath
 
   before(async function () {
-    // Set up a clean workspace before each test
     console.log("log 1: Before commands.js test execution is running")
 
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
@@ -24,16 +23,31 @@ describe('Commands', function () {
     const workspaceFolder = vscode.Uri.file(tempWorkspacePath)
     vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
 
-    // Create a new .js file and add content
-    const document = await vscode.workspace.openTextDocument({
-      content: 'const variableOne = 42\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment',
-      language: 'javascript'
-    })
+    // Give some time for the workspace to update
+    await new Promise(resolve => setTimeout(resolve, 500))
 
-    await vscode.window.showTextDocument(document)
+    try {
+      // Create a new .js file and add content
+      const document = await vscode.workspace.openTextDocument({
+        content: 'const variableOne = 42\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment',
+        language: 'javascript'
+      })
 
-    console.log("log 2: Before commands.js test execution finished running")
+      await vscode.window.showTextDocument(document)
+
+      // Check if the active text editor is correctly set
+      const editor = vscode.window.activeTextEditor
+      if (!editor) {
+        throw new Error("Failed to open text document in the editor")
+      }
+
+      console.log("log 2: Before commands.js test execution finished running")
+    } catch (error) {
+      console.error("Error in before hook:", error)
+      throw error
+    }
   })
+
 
   afterEach(function () {
     // Clean up the workspace after each test

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -10,8 +10,8 @@ const vscode = require('vscode')
 describe('Commands', function () {
   let tempWorkspacePath
 
-  beforeEach(async function () {
-    // Create the temporary workspace folder
+  beforeEach(function () {
+    // Set up a clean workspace before each test
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
 
     if (!fs.existsSync(tempWorkspacePath)) {
@@ -20,13 +20,21 @@ describe('Commands', function () {
 
     // Constructs a new file path for a file
     const workspaceFolder = vscode.Uri.file(tempWorkspacePath)
-    await vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
+    return vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
   })
 
   afterEach(function () {
-    if (!fs.existsSync(tempWorkspacePath)) {
-      fs.rmdir(tempWorkspacePath)
-    }
+    // Clean up the workspace after each test
+    return new Promise((resolve, reject) => {
+      if (fs.existsSync(tempWorkspacePath)) {
+        fs.rmdir(tempWorkspacePath, (err) => {
+          if (err) reject(err)
+          resolve()
+        })
+      } else {
+        resolve()
+      }
+    })
   })
 
   describe('addConsole() command', function () {
@@ -48,34 +56,9 @@ describe('Commands', function () {
 
         await vscode.commands.executeCommand('logify.addConsole')
 
-        const result = editor.document.getText()
+        const result = await editor.document.getText()
 
         assert.strictEqual(result, 'const myVariable = 42\nconsole.dir(myVariable, { depth: null, color: true })')
-      })
-    })
-
-    describe('when a file has content as well as the variable', function () {
-      before(async function () {
-        // Create a new .js file and add content
-        const document = await vscode.workspace.openTextDocument({
-          content: 'const myVariable = 42\n//This is a comment\n//This is another comment',
-          language: 'javascript'
-        })
-
-        await vscode.window.showTextDocument(document)
-      })
-
-      it('Adds a console underneath the highlighted variable with the content directly underneath', async function () {
-        // Select the highlighted variable
-        const editor = vscode.window.activeTextEditor
-        editor.selection = new vscode.Selection(0, 6, 0, 16)
-
-        await vscode.commands.executeCommand('logify.addConsole')
-
-        const result = editor.document.getText()
-        console.log('🚀🚀🚀 ~ result:', result)
-
-        assert.strictEqual(result, 'const myVariable = 42\nconsole.dir(myVariable, { depth: null, color: true })\n//This is a comment\n//This is another comment')
       })
     })
   })

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -48,6 +48,7 @@ describe('Commands', function () {
   describe('addConsole() command', function () {
     describe('when there is no content surrounding the variable', function () {
       it('adds a console underneath the highlighted variable', async function () {
+        console.log("Before commands.js test execution is running")
         // Select the highlighted variable
         const editor = vscode.window.activeTextEditor
         editor.selection = new vscode.Selection(0, 6, 0, 17)

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -12,7 +12,7 @@ describe('Commands', function () {
 
   before(async function () {
     // Set up a clean workspace before each test
-    console.log("Before commands.js test execution is running")
+    console.log("log 1: Before commands.js test execution is running")
 
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
 
@@ -31,6 +31,8 @@ describe('Commands', function () {
     })
 
     await vscode.window.showTextDocument(document)
+
+    console.log("log 2: Before commands.js test execution finished running")
   })
 
   afterEach(function () {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -91,7 +91,7 @@ describe('Commands', function () {
 
         // Execute the command and wait 0.2 seconds as the tests are running too fast
         await vscode.commands.executeCommand('logify.addConsole')
-        await new Promise(resolve => setTimeout(resolve, 200))
+        await new Promise(resolve => setTimeout(resolve, 1000))
 
         const result = await editor.document.getText()
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -12,6 +12,8 @@ describe('Commands', function () {
 
   before(async function () {
     // Set up a clean workspace before each test
+    console.log("Before commands.js test execution is running")
+
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
 
     if (!fs.existsSync(tempWorkspacePath)) {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -15,33 +15,44 @@ describe('Commands', function () {
 
     tempWorkspacePath = path.join(__dirname, 'tempWorkspace')
 
+    console.log("log 2: After tempWorkspacePath")
+
     if (!fs.existsSync(tempWorkspacePath)) {
       fs.mkdirSync(tempWorkspacePath)
     }
+
+    console.log("log 3: After creating directory")
 
     // Constructs a new file path for a file
     const workspaceFolder = vscode.Uri.file(tempWorkspacePath)
     vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
 
-    // Give some time for the workspace to update
-    await new Promise(resolve => setTimeout(resolve, 500))
+    console.log("log 4: After constructing the workspaceFolder")
 
     try {
+      // Wait for the workspace to be ready
+      await new Promise(resolve => setTimeout(resolve, 1000))
+
       // Create a new .js file and add content
       const document = await vscode.workspace.openTextDocument({
         content: 'const variableOne = 42\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment',
         language: 'javascript'
       })
 
-      await vscode.window.showTextDocument(document)
+      console.log("log 5: After creating the .js file")
 
-      // Check if the active text editor is correctly set
-      const editor = vscode.window.activeTextEditor
+      const editor = await vscode.window.showTextDocument(document, { preview: false, preserveFocus: false })
+
+      console.log("log 6: After opening the text document")
+
+      // Ensure the editor is ready before moving on
+      await new Promise(resolve => setTimeout(resolve, 500))
+
       if (!editor) {
         throw new Error("Failed to open text document in the editor")
       }
 
-      console.log("log 2: Before commands.js test execution finished running")
+      console.log("log 7: Before commands.js test execution finished running")
     } catch (error) {
       console.error("Error in before hook:", error)
       throw error

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -27,8 +27,6 @@ describe('Commands', function () {
     if (!fs.existsSync(tempWorkspacePath)) {
       fs.rmdir(tempWorkspacePath)
     }
-
-
   })
 
   describe('addConsole() command', function () {
@@ -53,6 +51,31 @@ describe('Commands', function () {
         const result = editor.document.getText()
 
         assert.strictEqual(result, 'const myVariable = 42\nconsole.dir(myVariable, { depth: null, color: true })')
+      })
+    })
+
+    describe('when a file has content as well as the variable', function () {
+      before(async function () {
+        // Create a new .js file and add content
+        const document = await vscode.workspace.openTextDocument({
+          content: 'const myVariable = 42\n//This is a comment\n//This is another comment',
+          language: 'javascript'
+        })
+
+        await vscode.window.showTextDocument(document)
+      })
+
+      it('Adds a console underneath the highlighted variable with the content directly underneath', async function () {
+        // Select the highlighted variable
+        const editor = vscode.window.activeTextEditor
+        editor.selection = new vscode.Selection(0, 6, 0, 16)
+
+        await vscode.commands.executeCommand('logify.addConsole')
+
+        const result = editor.document.getText()
+        console.log('🚀🚀🚀 ~ result:', result)
+
+        assert.strictEqual(result, 'const myVariable = 42\nconsole.dir(myVariable, { depth: null, color: true })\n//This is a comment\n//This is another comment')
       })
     })
   })

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -23,12 +23,6 @@ describe('Commands', function () {
 
     console.log("log 3: After creating directory")
 
-    // Constructs a new file path for a file
-    const workspaceFolder = vscode.Uri.file(tempWorkspacePath)
-    vscode.workspace.updateWorkspaceFolders(0, null, { uri: workspaceFolder })
-
-    console.log("log 4: After constructing the workspaceFolder")
-
     try {
       // Wait for the workspace to be ready
       await new Promise(resolve => setTimeout(resolve, 1000))
@@ -58,7 +52,6 @@ describe('Commands', function () {
       throw error
     }
   })
-
 
   afterEach(function () {
     // Clean up the workspace after each test

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,15 +1,19 @@
-const assert = require('assert');
+const assert = require('assert')
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-const vscode = require('vscode');
+const vscode = require('vscode')
 // const myExtension = require('../extension');
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+	vscode.window.showInformationMessage('Start all tests.')
+
+	console.log("Before extension.js test execution is running")
 
 	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
-});
+		assert.strictEqual(-1, [1, 2, 3].indexOf(5))
+		assert.strictEqual(-1, [1, 2, 3].indexOf(0))
+	})
+
+	console.log("Before extension.js test execution is finished")
+})


### PR DESCRIPTION
The main functionality provided by logify is the ability to highlight text and add a `console.dir()` below the highlighted variable. I first want to add the ability to `console.dir()` by highlighting a variable.

This PR adds the ability to highlight a section of text that will be put in `console.dir()`