### PR TITLE
Add setting option for toggling prefix Console Log 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode-test/
 *.vsix
+tempWorkspace

--- a/package.json
+++ b/package.json
@@ -19,9 +19,31 @@
       },
       {
         "command": "logify.addConsole",
-        "title": "Add console.dir()"
+        "title": "Logify: Add Console Dir"
+      },
+      {
+        "command": "logify.toggleShowVariableNameLog",
+        "title": "Logify: Toggle Descriptive Console Log"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Logify Settings",
+      "properties": {
+        "logify.logOptions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "showVariableNameLog"
+            ]
+          },
+          "default": [],
+          "description": "Add console.log with variable name above console.dir",
+          "uniqueItems": true
+        }
+      }
+    }
   },
   "scripts": {
     "lint": "eslint .",

--- a/src/commands.js
+++ b/src/commands.js
@@ -8,31 +8,42 @@ const vscode = require('vscode')
  */
 function addConsole() {
 	const editor = vscode.window.activeTextEditor
+	if (!editor) return
+
 	const document = editor.document
 	const highlightedVariable = getHighlightedVariable()
+	if (!highlightedVariable) return
 
-	if (highlightedVariable) {
-		const { linePosition, highlightedText } = highlightedVariable
+	const { linePosition, highlightedText } = highlightedVariable
 
-		if (linePosition >= 0 && linePosition <= document.lineCount) {
-			editor.edit((editBuilder) => {
-				if (linePosition + 1 === document.lineCount) {
-					const position = new vscode.Position(linePosition + 1, 0)
-					editBuilder.insert(position, '\n' + `console.dir(${highlightedText}, { depth: null, color: true })`)
-				} else {
-					const position = new vscode.Position(linePosition + 1, 0)
-					editBuilder.insert(position, `console.dir(${highlightedText}, { depth: null, color: true })` + '\n')
-				}
-			}).then(success => {
-				if (success) {
-					console.log('Console statement added successfully.')
-				} else {
-					console.error('Failed to add console statement.')
-				}
-			})
-		}
+	const config = vscode.workspace.getConfiguration('logify')
+	const options = config.get('logOptions', [])
+	const showVariableNameLog = options.includes('showVariableNameLog')
+
+	let logText = ''
+
+	if (showVariableNameLog) {
+		logText += `console.log('🚀🚀🚀 ~ ${highlightedText}:')\n`
+	}
+
+	logText += `console.dir(${highlightedText}, { depth: null, colors: true })`
+
+	if (linePosition >= 0 && linePosition <= document.lineCount) {
+		editor.edit((editBuilder) => {
+			const position = new vscode.Position(linePosition + 1, 0)
+			const insertText = (linePosition + 1 === document.lineCount ? '\n' : '') + logText
+			editBuilder.insert(position, insertText)
+		}).then(success => {
+			if (success) {
+				console.log('Console statement added successfully.')
+			} else {
+				console.error('Failed to add console statement.')
+			}
+		})
 	}
 }
+
+
 
 /**
  * Retrieves the currently highlighted text from the document and returns the highlighted variable and its

--- a/src/commands.js
+++ b/src/commands.js
@@ -26,7 +26,7 @@ function addConsole() {
 		logText += `console.log('🚀🚀🚀 ~ ${highlightedText}:')\n`
 	}
 
-	logText += `console.dir(${highlightedText}, { depth: null, colors: true })`
+	logText += `console.dir(${highlightedText}, { depth: null, colors: true })\n`
 
 	if (linePosition >= 0 && linePosition <= document.lineCount) {
 		editor.edit((editBuilder) => {

--- a/src/extension.js
+++ b/src/extension.js
@@ -2,7 +2,7 @@
 
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-const vscode = require('vscode');
+const vscode = require('vscode')
 const { addConsole } = require('./commands')
 
 // This method is called when your extension is activated
@@ -15,7 +15,7 @@ function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "logify" is now active!');
+	console.log('Congratulations, your extension "logify" is now active!')
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with  registerCommand
@@ -24,16 +24,35 @@ function activate(context) {
 		// The code you place here will be executed every time your command is executed
 
 		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from logify!');
-	});
+		vscode.window.showInformationMessage('Hello World from logify!')
+	})
 
 	const addConsoleCommand = vscode.commands.registerCommand('logify.addConsole', function () {
 		addConsole()
-		vscode.window.showInformationMessage('Activate console command');
-	});
+		vscode.window.showInformationMessage('Activate console command')
+	})
+
+	const toggleShowVariableNameLog = vscode.commands.registerCommand('logify.toggleShowVariableNameLog', async () => {
+		const config = vscode.workspace.getConfiguration('logify')
+		const currentOptions = config.get('logOptions', [])
+
+		const settingKey = 'showVariableNameLog'
+		const isEnabled = currentOptions.includes(settingKey)
+
+		const updatedOptions = isEnabled
+			? currentOptions.filter(opt => opt !== settingKey)
+			: [...currentOptions, settingKey]
+
+		await config.update('logOptions', updatedOptions, vscode.ConfigurationTarget.Global)
+
+		vscode.window.showInformationMessage(
+			`Descriptive console log is ${isEnabled ? 'disabled' : 'enabled'}`
+		)
+	})
 
 	context.subscriptions.push(disposable)
 	context.subscriptions.push(addConsoleCommand)
+	context.subscriptions.push(toggleShowVariableNameLog)
 }
 
 // This method is called when your extension is deactivated

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -110,5 +110,44 @@ describe('Commands', function () {
         assert.strictEqual(result, expectedText)
       })
     })
+
+    describe('when descriptive console log is enabled', function () {
+      beforeEach(async function () {
+        const config = vscode.workspace.getConfiguration('logify')
+        await config.update('logOptions', ['showVariableNameLog'], vscode.ConfigurationTarget.Global)
+      })
+
+      afterEach(async function () {
+        const config = vscode.workspace.getConfiguration('logify')
+        await config.update('logOptions', [''], vscode.ConfigurationTarget.Global)
+      })
+
+      it('adds console.log and console.dir for the highlighted variable', async function () {
+        const editor = vscode.window.activeTextEditor
+
+        editor.selection = new vscode.Selection(7, 6, 7, 19)
+
+        // Run the command
+        await vscode.commands.executeCommand('logify.addConsole')
+        await new Promise(resolve => setTimeout(resolve, 500))
+
+        const result = editor.document.getText()
+
+        const expectedText = 'const variableOne = 42\n' +
+        'console.dir(variableOne, { depth: null, colors: true })\n' +
+        '\n' +
+        'const variableTwo = 24\n' +
+        'console.dir(variableTwo, { depth: null, colors: true })\n'+
+        '//This is a comment\n' +
+        '//This is another comment' +
+        '\n' +
+        'const variableThree = 65\n' +
+        `console.log('🚀🚀🚀 ~ variableThree:')\n` +
+        'console.dir(variableThree, { depth: null, colors: true })\n'
+
+        assert.strictEqual(result.trim(), expectedText.trim())
+      })
+    })
+
   })
 })

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -65,7 +65,7 @@ describe('Commands', function () {
 
         const result = await editor.document.getText()
 
-        assert.strictEqual(result, 'const variableOne = 42\nconsole.dir(variableOne, { depth: null, color: true })\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment')
+        assert.strictEqual(result, 'const variableOne = 42\nconsole.dir(variableOne, { depth: null, colors: true })\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment')
       })
     })
 
@@ -82,7 +82,7 @@ describe('Commands', function () {
         const result = await editor.document.getText()
 
         // Check if the console is added in the correct location
-        const expectedText = 'const variableOne = 42\nconsole.dir(variableOne, { depth: null, color: true })\n\nconst variableTwo = 24\nconsole.dir(variableTwo, { depth: null, color: true })\n//This is a comment\n//This is another comment'
+        const expectedText = 'const variableOne = 42\nconsole.dir(variableOne, { depth: null, colors: true })\n\nconst variableTwo = 24\nconsole.dir(variableTwo, { depth: null, colors: true })\n//This is a comment\n//This is another comment'
 
         assert.strictEqual(result, expectedText)
       })

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -23,7 +23,13 @@ describe('Commands', function () {
 
       // Create a new .js file and add content
       const document = await vscode.workspace.openTextDocument({
-        content: 'const variableOne = 42\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment',
+        content: 'const variableOne = 42\n' +
+        '\n'+
+        'const variableTwo = 24\n' +
+        '//This is a comment\n' +
+        '//This is another comment' +
+        '\n' +
+        'const variableThree = 65',
         language: 'javascript'
       })
 
@@ -65,7 +71,16 @@ describe('Commands', function () {
 
         const result = await editor.document.getText()
 
-        assert.strictEqual(result, 'const variableOne = 42\nconsole.dir(variableOne, { depth: null, colors: true })\n\nconst variableTwo = 24\n//This is a comment\n//This is another comment')
+        const expectedText = 'const variableOne = 42\n' +
+        'console.dir(variableOne, { depth: null, colors: true })\n' +
+        '\n' +
+        'const variableTwo = 24\n' +
+        '//This is a comment\n' +
+        '//This is another comment' +
+        '\n' +
+        'const variableThree = 65'
+
+        assert.strictEqual(result, expectedText)
       })
     })
 
@@ -82,7 +97,15 @@ describe('Commands', function () {
         const result = await editor.document.getText()
 
         // Check if the console is added in the correct location
-        const expectedText = 'const variableOne = 42\nconsole.dir(variableOne, { depth: null, colors: true })\n\nconst variableTwo = 24\nconsole.dir(variableTwo, { depth: null, colors: true })\n//This is a comment\n//This is another comment'
+        const expectedText = 'const variableOne = 42\n' +
+        'console.dir(variableOne, { depth: null, colors: true })\n' +
+        '\n' +
+        'const variableTwo = 24\n' +
+        'console.dir(variableTwo, { depth: null, colors: true })\n'+
+        '//This is a comment\n' +
+        '//This is another comment' +
+        '\n' +
+        'const variableThree = 65'
 
         assert.strictEqual(result, expectedText)
       })

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { it, describe, before, afterEach } = require('mocha')
+const { it, describe, afterEach, before, beforeEach} = require('mocha')
 
 const assert = require('assert')
 const fs = require('fs')
@@ -46,7 +46,11 @@ describe('Commands', function () {
     }
   })
 
-  afterEach(function () {
+  afterEach(async function () {
+    // After each test, clear out our setting
+    const config = vscode.workspace.getConfiguration('logify')
+    await config.update('logOptions', [], vscode.ConfigurationTarget.Global)
+
     // Clean up the workspace after each test
     return new Promise((resolve, reject) => {
       if (fs.existsSync(tempWorkspacePath)) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4884

The main advantage provided by logify is being able to print an entire object to the terminal. However, using `console.dir()` does not allow for a prefix like `console.log()` does. e.g `console.log('🚀🚀🚀 ~ result:', result)`.

To work around this, users will have the ability to toggle between allowing a prefix `console.log(variable)` containing the variable name. This will provide an easy way for users to identify printed values in the terminal.

This PR will add a setting option for toggling a prefix `console.log()` for logify.