### PR TITLE
Add keyboard shortcuts for `console.dir` insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   ],
   "activationEvents": [],
   "main": "./src/extension.js",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "vscode-test"
+  },
   "contributes": {
     "commands": [
       {
@@ -43,11 +47,15 @@
           "uniqueItems": true
         }
       }
-    }
-  },
-  "scripts": {
-    "lint": "eslint .",
-    "test": "vscode-test"
+    },
+    "keybindings": [
+      {
+        "command": "logify.addConsole",
+        "key": "ctrl+alt+l",
+        "mac": "ctrl+alt+l",
+        "when": "editorTextFocus && !editorReadonly"
+      }
+    ]
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/src/extension.js
+++ b/src/extension.js
@@ -29,7 +29,6 @@ function activate(context) {
 
 	const addConsoleCommand = vscode.commands.registerCommand('logify.addConsole', function () {
 		addConsole()
-		vscode.window.showInformationMessage('Activate console command')
 	})
 
 	const toggleShowVariableNameLog = vscode.commands.registerCommand('logify.toggleShowVariableNameLog', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4884

Currently, Logify has the ability to add `console.dir()` to a users editor. In order to compete with other logging extensions, users typically have the option to use keyboard shortcuts to add a log. This makes the ability to add `console.dir()` much faster and more satisfying.

This PR adds keyboard shortcuts for `console.dir()` to Logify.