### PR TITLE
Add configuration settings for toggling options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vscode-test/
 *.vsix
 tempWorkspace
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "logify.helloWorld",
-        "title": "Hello World"
-      },
-      {
         "command": "logify.addConsole",
         "title": "Logify: Add Console Dir"
       },

--- a/package.json
+++ b/package.json
@@ -31,20 +31,12 @@
       }
     ],
     "configuration": {
-      "type": "object",
-      "title": "Logify Settings",
+      "title": "Logify settings",
       "properties": {
-        "logify.logOptions": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "showVariableNameLog"
-            ]
-          },
-          "default": [],
-          "description": "Add console.log with variable name above console.dir",
-          "uniqueItems": true
+        "logify.enableDescriptiveLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include a descriptive console.log with the variable name before the console.dir call."
         }
       }
     },

--- a/src/commands.js
+++ b/src/commands.js
@@ -17,12 +17,11 @@ function addConsole() {
 	const { linePosition, highlightedText } = highlightedVariable
 
 	const config = vscode.workspace.getConfiguration('logify')
-	const options = config.get('logOptions', [])
-	const showVariableNameLog = options.includes('showVariableNameLog')
+	const enableDescriptiveLog = config.get('enableDescriptiveLogging', false)
 
 	let logText = ''
 
-	if (showVariableNameLog) {
+	if (enableDescriptiveLog) {
 		logText += `console.log('🚀🚀🚀 ~ ${highlightedText}:')\n`
 	}
 
@@ -42,8 +41,6 @@ function addConsole() {
 		})
 	}
 }
-
-
 
 /**
  * Retrieves the currently highlighted text from the document and returns the highlighted variable and its

--- a/src/extension.js
+++ b/src/extension.js
@@ -5,28 +5,14 @@
 const vscode = require('vscode')
 const { addConsole } = require('./commands')
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
-
 /**
+ * This method is called when your extension is activated
+ * Your extension is activated the very first time the command is execute
+ *
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "logify" is now active!')
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('logify.helloWorld', function () {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from logify!')
-	})
-
+	// Main command that adds console.dir
 	const addConsoleCommand = vscode.commands.registerCommand('logify.addConsole', function () {
 		addConsole()
 	})

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,25 +31,19 @@ function activate(context) {
 		addConsole()
 	})
 
+	// Toggles the boolean setting "logify.showVariableNameLog"
 	const toggleShowVariableNameLog = vscode.commands.registerCommand('logify.toggleShowVariableNameLog', async () => {
 		const config = vscode.workspace.getConfiguration('logify')
-		const currentOptions = config.get('logOptions', [])
+		const isEnabled = config.get('enableDescriptiveLog', false)
 
-		const settingKey = 'showVariableNameLog'
-		const isEnabled = currentOptions.includes(settingKey)
-
-		const updatedOptions = isEnabled
-			? currentOptions.filter(opt => opt !== settingKey)
-			: [...currentOptions, settingKey]
-
-		await config.update('logOptions', updatedOptions, vscode.ConfigurationTarget.Global)
+		await config.update('enableDescriptiveLog', !isEnabled, vscode.ConfigurationTarget.Global)
 
 		vscode.window.showInformationMessage(
-			`Descriptive console log is ${isEnabled ? 'disabled' : 'enabled'}`
+			`Descriptive console log is now ${!isEnabled ? 'enabled' : 'disabled'}`
 		)
 	})
 
-	context.subscriptions.push(disposable)
+	// Register all commands
 	context.subscriptions.push(addConsoleCommand)
 	context.subscriptions.push(toggleShowVariableNameLog)
 }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -49,7 +49,7 @@ describe('Commands', function () {
   afterEach(async function () {
     // After each test, clear out our setting
     const config = vscode.workspace.getConfiguration('logify')
-    await config.update('logOptions', [], vscode.ConfigurationTarget.Global)
+    await config.update('enableDescriptiveLogging', false, vscode.ConfigurationTarget.Global)
 
     // Clean up the workspace after each test
     return new Promise((resolve, reject) => {
@@ -118,12 +118,12 @@ describe('Commands', function () {
     describe('when descriptive console log is enabled', function () {
       beforeEach(async function () {
         const config = vscode.workspace.getConfiguration('logify')
-        await config.update('logOptions', ['showVariableNameLog'], vscode.ConfigurationTarget.Global)
+        await config.update('enableDescriptiveLogging', true, vscode.ConfigurationTarget.Global)
       })
 
       afterEach(async function () {
         const config = vscode.workspace.getConfiguration('logify')
-        await config.update('logOptions', [''], vscode.ConfigurationTarget.Global)
+        await config.update('enableDescriptiveLogging', false, vscode.ConfigurationTarget.Global)
       })
 
       it('adds console.log and console.dir for the highlighted variable', async function () {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4884

As we add more and more functionality to logify, it is important we allow users to make the experience more enjoyable by personalising logify's functionality. Vscode allows us to do this through `configuration.settings`, meaning we can turn on and off functionality at will.

This PR adds basic `configuration.settings` to Logify.