### PR TITLE
Bug fix incorrect logify icon image path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "logify",
   "displayName": "Logify",
   "description": "Quickly insert colourful and deep-inspection console.dir statements in JavaScript.",
-  "icon": "./images/logify-icon.png",
+  "icon": "images/logify-icon.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/rvsiyad/logify.git"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4884

The previous icon path was incorrect, causing a warning during extension packaging.
This update points to the correct relative path so the extension icon displays properly in the VS Code Marketplace.

This PR fixes the image path for the logify logo