### PR TITLE
Fix missing publisher from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "logify",
   "displayName": "Logify",
+  "publisher": "rvsiyad",
   "description": "Quickly insert colourful and deep-inspection console.dir statements in JavaScript.",
   "icon": "images/logify-icon.png",
   "repository": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4884

The `publisher`` field is required to publish an extension to the VS Code Marketplace. It identifies the account or organization responsible for the extension. This update ensures the extension can be packaged and published without errors.

This PR adds the `publisher` to the package.json for logify.