### PR TITLE
Fix incorrect name used for publisher in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logify",
   "displayName": "Logify",
-  "publisher": "rvsiyad",
+  "publisher": "RobleSiyad",
   "description": "Quickly insert colourful and deep-inspection console.dir statements in JavaScript.",
   "icon": "images/logify-icon.png",
   "repository": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4884

The `publisher` field in the `package.json` was updated to match the actual publisher ID (RobleSiyad) for the extension. This change ensures consistency between the local configuration and the VS Code Marketplace publisher account, enabling successful publishing of the extension.

This PR changes the publisher name in the package.json file for logify.